### PR TITLE
Replaced wrong "Skipped" outcome with "NotExecuted"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-trx",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "trx TestCafe reporter plugin.",
   "repository": "https://github.com/keyrun/testcafe-reporter-trx",
   "author": {

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default function () {
             const hasErr = !!testRunInfo.errs.length;
             let result = hasErr ? `Failed` : `Passed`;
 
-            result = testRunInfo.skipped ? 'Skipped' : result;
+            result = testRunInfo.skipped ? 'NotExecuted' : result;
             const testResults = {};
 
             testResults.name = `test "${name}" in fixture "${this.fixtureName}"`;


### PR DESCRIPTION
Accordingly to node-trx there is no "Skipped" outcome, but "NotExecuted"